### PR TITLE
Use API v2.1 instead v1.0

### DIFF
--- a/lib/omniauth/strategies/clever.rb
+++ b/lib/omniauth/strategies/clever.rb
@@ -55,7 +55,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/me').parsed
+        @raw_info ||= access_token.get('/v2.1/me').parsed
       end
 
       # Fix unknown redirect uri bug by NOT appending the query string to the callback url.


### PR DESCRIPTION
We use 'api.clever.com/v2.1/me' instead of 'api.clever.com/me' because the new version contains the 'authorized_by' field in response